### PR TITLE
(Fix) Remove wrong alert on Set Metadata page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -183,7 +183,7 @@ class App extends Component {
         console.error(error.message)
         let errDescription
         if (error.message.includes(constants.userDeniedTransactionPattern))
-          errDescription = `Error: User ${constants.userDeniedTransactionPattern}`
+          errDescription = `Error: ${constants.userDeniedTransactionPattern}`
         else errDescription = error.message
         this.setState({ loading: false })
         var msg = `

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ import { constants } from './constants'
 
 const history = createBrowserHistory()
 const baseRootPath = '/poa-dapps-validators'
+const setMetadataPath = `${baseRootPath}/set`
+const pendingChangesPath = `${baseRootPath}/pending-changes`
 const navigationData = [
   {
     icon: 'link-icon-all',
@@ -29,12 +31,12 @@ const navigationData = [
   {
     icon: 'link-icon-set-metadata',
     title: 'Set Metadata',
-    url: `${baseRootPath}/set`
+    url: setMetadataPath
   },
   {
     icon: 'link-icon-pending-changes',
     title: 'Pending Changes',
-    url: `${baseRootPath}/pending-changes`
+    url: pendingChangesPath
   }
 ]
 
@@ -55,7 +57,7 @@ class AppMainRouter extends Component {
     this.getNetIdClass = this.getNetIdClass.bind(this)
 
     this.state = {
-      showSearch: true,
+      showSearch: history.location.pathname !== setMetadataPath,
       keysManager: null,
       metadataContract: null,
       poaConsensus: null,
@@ -125,9 +127,7 @@ class AppMainRouter extends Component {
     })
   }
   onRouteChange() {
-    const setMetadata = baseRootPath + '/set'
-
-    if (history.location.pathname === setMetadata) {
+    if (history.location.pathname === setMetadataPath) {
       this.setState({ showSearch: false })
 
       if (this.state.injectedWeb3 === false) {
@@ -145,12 +145,10 @@ class AppMainRouter extends Component {
     return ''
   }
   onSetRender() {
-    if (!this.state.netId) {
-      return ''
+    if (!this.state.votingKey) {
+      return '' // prevent rendering if the keys are not loaded yet
     }
-    return this.checkForVotingKey(() => {
-      return <App web3Config={this.state} viewTitle={navigationData[1]['title']} />
-    })
+    return <App web3Config={this.state} viewTitle={navigationData[1]['title']} />
   }
   toggleMobileMenu = () => {
     this.setState(prevState => ({ showMobileMenu: !prevState.showMobileMenu }))
@@ -277,9 +275,9 @@ class AppMainRouter extends Component {
             } ${this.getNetIdClass()}`}
           >
             <Route exact path="/" render={this.onAllValidatorsRender} web3Config={this.state} />
-            <Route exact path={`${baseRootPath}/`} render={this.onAllValidatorsRender} web3Config={this.state} />
-            <Route path={`${baseRootPath}/pending-changes`} render={this.onPendingChangesRender} />
-            <Route path={`${baseRootPath}/set`} render={this.onSetRender} />
+            <Route exact path={baseRootPath} render={this.onAllValidatorsRender} web3Config={this.state} />
+            <Route path={pendingChangesPath} render={this.onPendingChangesRender} />
+            <Route path={setMetadataPath} render={this.onSetRender} />
           </div>
           <Footer netId={this.state.netId} />
         </section>


### PR DESCRIPTION
- (Mandatory) Description
This PR removes the wrong alert reported in https://github.com/poanetwork/poa-dapps-validators/pull/88, makes a little refactoring, and solves the issue https://github.com/poanetwork/poa-dapps-validators/issues/89.

- (Mandatory) What is it: (Fix), (Feature), or (Refactor)
(Fix)