### PR TITLE
(fix) missing 'miningKey' attribute from buttons.

### DIFF
--- a/src/components/AllValidators/index.js
+++ b/src/components/AllValidators/index.js
@@ -161,7 +161,6 @@ export default class AllValidators extends Component {
       let childrenWithProps = React.Children.map(this.props.children, child => {
         return React.cloneElement(child, { miningkey: validator.address })
       })
-
       validators.push(
         <Validator
           address={validator.address}

--- a/src/components/ButtonConfirm/index.js
+++ b/src/components/ButtonConfirm/index.js
@@ -1,13 +1,21 @@
 import React from 'react'
 import { IconConfirm } from '../IconConfirm'
 
-export const ButtonConfirm = ({ extraClassName = '', networkBranch, onClick, disabled = false, text = 'Confirm' }) => {
+export const ButtonConfirm = ({
+  extraClassName = '',
+  networkBranch,
+  onClick,
+  disabled = false,
+  text = 'Confirm',
+  ...props
+}) => {
   return (
     <button
       className={`sw-ButtonConfirm ${extraClassName} sw-ButtonConfirm-${networkBranch}`}
       disabled={disabled}
       onClick={onClick}
       type="button"
+      {...props}
     >
       <span className="sw-ButtonConfirm_Text">{text}</span> <IconConfirm networkBranch={networkBranch} />
     </button>

--- a/src/components/ButtonFinalize/index.js
+++ b/src/components/ButtonFinalize/index.js
@@ -6,7 +6,8 @@ export const ButtonFinalize = ({
   extraClassName = '',
   networkBranch,
   onClick,
-  text = 'Finalize'
+  text = 'Finalize',
+  ...props
 }) => {
   return (
     <button
@@ -14,6 +15,7 @@ export const ButtonFinalize = ({
       disabled={disabled}
       onClick={onClick}
       type="button"
+      {...props}
     >
       <span className="sw-ButtonFinalize_Text">{text}</span> <IconFinalize networkBranch={networkBranch} />
     </button>


### PR DESCRIPTION
Closes #108

**Description:**
   
Fixed the missing `miningKey` attribute from the _ButtonFinalize_ and _ButtonConfirm_ components.

Seems to be there now:

<img width="496" alt="Screen Shot 2019-05-15 at 18 22 06" src="https://user-images.githubusercontent.com/4015436/57810764-f2ff3500-773e-11e9-9808-3ee5305944f7.png">
