### PR TITLE
(Fix) Remove subscriber for legacy MetaMask account switcher event

### DIFF
--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -37,14 +37,16 @@ export default async function getWeb3(netId = defaultNetId, onAccountChange) {
       console.error('Unlock your wallet')
     }
 
-    let currentAccount = defaultAccount ? defaultAccount.toLowerCase() : ''
-    web3.currentProvider.publicConfigStore.on('update', async function(obj) {
-      const account = obj.selectedAddress
-      if (account && account !== currentAccount) {
-        currentAccount = account
-        await onAccountChange(account)
-      }
-    })
+    if (web3.currentProvider.publicConfigStore) {
+      let currentAccount = defaultAccount ? defaultAccount.toLowerCase() : ''
+      web3.currentProvider.publicConfigStore.on('update', async function(obj) {
+        const account = obj.selectedAddress
+        if (account && account !== currentAccount) {
+          currentAccount = account
+          await onAccountChange(account)
+        }
+      })
+    }
 
     const web3NetId = await web3.eth.net.getId()
     if (web3NetId === netId) {


### PR DESCRIPTION
- (Mandatory) Description
    Currently, we have the error when loading DApp because of yesterday's update of MetaMask to `v7.7.0`:
    <img src="https://user-images.githubusercontent.com/33550681/70120585-fe379500-167d-11ea-8a0d-3bd16e215770.png" width="300" />
    This PR fixes the error keeping backward compatible behavior. MetaMask released `v7.7.0` on `December 3rd` and removed `web3.currentProvider.publicConfigStore` field from their web3 provider. This is part of upcoming breaking changes described in https://medium.com/metamask/breaking-changes-to-the-metamask-inpage-provider-b4dde069dd0a. I tried to replace MetaMask's `window.ethereum` API with the new one, but that doesn't work yet. We will replace that later (and before `January 13, 2020` when the MetaMask's changes suppose to work properly).

- (Mandatory) What is it: (Fix), (Feature), or (Refactor) in Title
(Fix)